### PR TITLE
Fix IP address detection

### DIFF
--- a/lib/cct/cloud/control_node.rb
+++ b/lib/cct/cloud/control_node.rb
@@ -102,7 +102,7 @@ module Cct
       @status = data["status"]
       data = crowbar.node(name)
       @data = data
-      @ip = data["ipaddress"]
+      @ip = data["crowbar"]["network"]["admin"]["address"]
       @hostname = data["hostname"]
       @domain = data["domain"]
 


### PR DESCRIPTION
Just using "ipaddress" is wrong as this is the attribute from
ohai and ohai just returns one random ip address from the host,
not a very specific one, so with some luck (or not luck), the
IP address was not pingable. Always use admin network instead.
