### PR TITLE
Reenable https in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in cct.gemspec
 gemspec


### PR DESCRIPTION
We disabled https because we can not run bundler on SLE11SP3 with https
enabled. Now we switched to SLE12 and it works again.

Fixed #9
