### PR TITLE
Add database barclamp tests

### DIFF
--- a/features/barclamp_database.feature
+++ b/features/barclamp_database.feature
@@ -1,0 +1,26 @@
+Feature: Test the database server resource
+  As an administrator
+  I want to make sure the database service is deployed successfully
+  In order to be available for other services later
+
+  Background:
+    Given the chef role "database-server" exists on admin node
+    And the "database" cookbook exists on the admin node
+
+  @postgresql
+  Scenario: Database barclamp is deployed using PostgreSQL as backend
+    Given the "postgresql" cookbook exists on the admin node
+    And the barclamp proposal is using "postgresql" as sql engine
+    When the node with database role has been detected successfully
+    Then I can establish connection to "postgresql" database server
+    And I can create a database called "cucumber_test"
+    And I can drop the database "cucumber_test" successfully
+
+  @mysql
+  Scenario: Database barclamp is deployed using mySql as backend
+    Given the "mysql" cookbook exists on the admin node
+    And the barclamp proposal is using "mysql" as sql engine
+    When the node with database role has been detected successfully
+    Then I can establish connection to "mysql" database server
+    And I can create a database called "cucumber_test"
+    And I can drop the database "cucumber_test" successfully

--- a/features/barclamp_database.feature
+++ b/features/barclamp_database.feature
@@ -12,15 +12,7 @@ Feature: Test the database server resource
     Given the "postgresql" cookbook exists on the admin node
     And the barclamp proposal is using "postgresql" as sql engine
     When the node with database role has been detected successfully
+    And the service "postgresql.service" is enabled and running on the detected node
     Then I can establish connection to "postgresql" database server
-    And I can create a database called "cucumber_test"
-    And I can drop the database "cucumber_test" successfully
-
-  @mysql
-  Scenario: Database barclamp is deployed using mySql as backend
-    Given the "mysql" cookbook exists on the admin node
-    And the barclamp proposal is using "mysql" as sql engine
-    When the node with database role has been detected successfully
-    Then I can establish connection to "mysql" database server
     And I can create a database called "cucumber_test"
     And I can drop the database "cucumber_test" successfully

--- a/features/step_definitions/barclamp_database/database_steps.rb
+++ b/features/step_definitions/barclamp_database/database_steps.rb
@@ -5,37 +5,48 @@ end
 
 When(/^the node with database role has been detected successfully$/) do
   json_response = JSON.parse(admin_node.exec!("crowbar database show default").output)
-  @node_fqdn = json_response["deployment"]["database"]["elements"]["database-server"].first
-  expect(@node_fqdn).not_to be_empty
+  @db_nodes = json_response["deployment"]["database"]["elements"]["database-server"]
+  expect(@db_nodes).not_to be_empty
 end
 
 Then(/^I can establish connection to "([^"]*)" database server$/) do |db_name|
   @db_name = db_name
   json_response = JSON.parse(admin_node.exec!("crowbar database show default").output)
   @password = json_response["attributes"]["database"]["db_maker_password"]
-  @node = nodes.find(fqdn: @node_fqdn)
-  case db_name
-  when "postgresql"
-    @node.exec!("PGPASSWORD=#{@password} psql -U db_maker -h #{@node.fqdn} postgres -c 'SELECT 1'")
-  when "mysql"
-    @node.exec!("mysql -u db_maker --password=#{@password}  -h #{@node.fqdn} -e 'SELECT 1'")
+  @db_nodes.each do |node_name|
+    node = nodes.find(fqdn: node_name)
+    case db_name
+    when "postgresql"
+      node.exec!("PGPASSWORD=#{@password} psql -U db_maker -h #{node.fqdn} postgres -c 'SELECT 1'")
+    end
   end
 end
 
 Then(/^I can create a database called "([^"]*)"$/) do |db|
-  case @db_name
-  when "postgresql"
-    @node.exec!("PGPASSWORD=#{@password} psql -U db_maker -h #{@node.fqdn} postgres -c 'CREATE DATABASE #{db}'")
-  when "mysql"
-    @node.exec!("mysql -u db_maker --password=#{@password}  -h #{@node.fqdn} -e 'CREATE DATABASE #{db}'")
+  @db_nodes.each do |node_name|
+    node = nodes.find(fqdn: node_name)
+    case @db_name
+    when "postgresql"
+      node.exec!("PGPASSWORD=#{@password} psql -U db_maker -h #{node.fqdn} postgres -c 'CREATE DATABASE #{db}'")
+    end
   end
 end
 
 Then(/^I can drop the database "([^"]*)" successfully$/) do |db|
-  case @db_name
-  when "postgresql"
-    @node.exec!("PGPASSWORD=#{@password} psql -U db_maker -h #{@node.fqdn} postgres -c 'DROP DATABASE #{db}'")
-  when "mysql"
-    @node.exec!("mysql -u db_maker --password=#{@password}  -h #{@node.fqdn} -e 'DROP DATABASE #{db}'")
+  @db_nodes.each do |node_name|
+    node = nodes.find(fqdn: node_name)
+    case @db_name
+    when "postgresql"
+      node.exec!("PGPASSWORD=#{@password} psql -U db_maker -h #{node.fqdn} postgres -c 'DROP DATABASE #{db}'")
+    end
   end
 end
+
+When(/^the service "([^"]*)" is enabled and running on the detected node$/) do |service_name|
+  @db_nodes.each do |node_name|
+    node = nodes.find(fqdn: node_name)
+    node.exec!("systemctl is-enabled #{service_name}")
+    node.exec!("systemctl is-active #{service_name}")
+  end
+end
+

--- a/features/step_definitions/barclamp_database/database_steps.rb
+++ b/features/step_definitions/barclamp_database/database_steps.rb
@@ -1,0 +1,41 @@
+Given(/^the barclamp proposal is using "([^"]*)" as sql engine$/) do |sql_engine_name|
+  json_response = JSON.parse(admin_node.exec!("crowbar database show default").output)
+  expect(json_response["attributes"]["database"]["sql_engine"]).to eq(sql_engine_name)
+end
+
+When(/^the node with database role has been detected successfully$/) do
+  json_response = JSON.parse(admin_node.exec!("crowbar database show default").output)
+  @node_fqdn = json_response["deployment"]["database"]["elements"]["database-server"].first
+  expect(@node_fqdn).not_to be_empty
+end
+
+Then(/^I can establish connection to "([^"]*)" database server$/) do |db_name|
+  @db_name = db_name
+  json_response = JSON.parse(admin_node.exec!("crowbar database show default").output)
+  @password = json_response["attributes"]["database"]["db_maker_password"]
+  @node = nodes.find(fqdn: @node_fqdn)
+  case db_name
+  when "postgresql"
+    @node.exec!("PGPASSWORD=#{@password} psql -U db_maker -h #{@node.fqdn} postgres -c 'SELECT 1'")
+  when "mysql"
+    @node.exec!("mysql -u db_maker --password=#{@password}  -h #{@node.fqdn} -e 'SELECT 1'")
+  end
+end
+
+Then(/^I can create a database called "([^"]*)"$/) do |db|
+  case @db_name
+  when "postgresql"
+    @node.exec!("PGPASSWORD=#{@password} psql -U db_maker -h #{@node.fqdn} postgres -c 'CREATE DATABASE #{db}'")
+  when "mysql"
+    @node.exec!("mysql -u db_maker --password=#{@password}  -h #{@node.fqdn} -e 'CREATE DATABASE #{db}'")
+  end
+end
+
+Then(/^I can drop the database "([^"]*)" successfully$/) do |db|
+  case @db_name
+  when "postgresql"
+    @node.exec!("PGPASSWORD=#{@password} psql -U db_maker -h #{@node.fqdn} postgres -c 'DROP DATABASE #{db}'")
+  when "mysql"
+    @node.exec!("mysql -u db_maker --password=#{@password}  -h #{@node.fqdn} -e 'DROP DATABASE #{db}'")
+  end
+end

--- a/features/step_definitions/barclamps/barclamp_steps.rb
+++ b/features/step_definitions/barclamps/barclamp_steps.rb
@@ -1,0 +1,7 @@
+Given(/^the chef role "([^"]*)" exists on admin node$/) do |role_name|
+  admin_node.exec!("knife role show #{role_name}")
+end
+
+Given(/^the "([^"]*)" cookbook exists on the admin node$/) do |cookbook_name|
+  admin_node.exec!("knife cookbook show #{cookbook_name}")
+end

--- a/tasks/features.rake
+++ b/tasks/features.rake
@@ -10,6 +10,6 @@ namespace :features do
 
   desc "Run barclamp tests"
   task :barclamps do
-    invoke_task "feature:barclamp:database:postgres"
+    invoke_task "feature:barclamp:database"
   end
 end

--- a/tasks/features.rake
+++ b/tasks/features.rake
@@ -3,7 +3,13 @@ namespace :features do
   task :base do
     invoke_task "feature:admin"
     invoke_task "feature:controller"
+    invoke_task "features:barclamps"
     invoke_task "feature:users"
     invoke_task "feature:images"
+  end
+
+  desc "Run barclamp tests"
+  task :barclamps do
+    invoke_task "feature:barclamp:database:postgres"
   end
 end

--- a/tasks/features/barclamp:database.rake
+++ b/tasks/features/barclamp:database.rake
@@ -1,0 +1,13 @@
+namespace :feature do
+  feature_name "Test the database server resource"
+
+  namespace :barclamp do
+    namespace :database do
+      desc "Verify the postresql database server"
+      feature_task :postgres, tags: :@postgresql
+
+      desc "Verify default database server"
+      task :default => :postgres
+    end
+  end
+end

--- a/tasks/features/barclamp:database.rake
+++ b/tasks/features/barclamp:database.rake
@@ -3,8 +3,11 @@ namespace :feature do
 
   namespace :barclamp do
     namespace :database do
-      desc "Verify the postresql database server"
       feature_task :postgres, tags: :@postgresql
+
     end
+
+    desc "Verify the database resource"
+    task :database => :"database:postgres"
   end
 end

--- a/tasks/features/barclamp:database.rake
+++ b/tasks/features/barclamp:database.rake
@@ -5,9 +5,6 @@ namespace :feature do
     namespace :database do
       desc "Verify the postresql database server"
       feature_task :postgres, tags: :@postgresql
-
-      desc "Verify default database server"
-      task :default => :postgres
     end
   end
 end


### PR DESCRIPTION
Database tests gets triggered with task `feature:barclamp:database`, are part of `features:barclamps` and included in `mkcloud cct`.
