### PR TITLE
Add tests for barclamp_keystone

### DIFF
--- a/features/barclamp_keystone.feature
+++ b/features/barclamp_keystone.feature
@@ -1,0 +1,21 @@
+@keystone
+Feature: Tests Openstack Keystone barclamp
+  As an actor
+  I want to perform various validations
+  In order to verify the feature functionality
+
+  Background:
+    Given the chef role "keystone-server" exists on admin node
+    And the "keystone" cookbook exists on the admin node
+
+  Scenario: Keystone deployment and functioning
+    Given the barclamp proposal is using the keystone identity service
+    When the node with keystone-server role has been detected successfully
+    And the "python-keystone" is installed in the controller node
+    And the "python-openstackclient" is installed in the controller node
+    Then I can create a new project "cucumber_test" on the cloud 
+    And I can create a new user "cucumber_user" for the "cucumber_test" project
+    And I can see the list of all available hosts on the cloud
+    And I can delete the project "cucumber_test" and user "cucumber_user"
+    
+

--- a/features/step_definitions/barclamp_keystone/keystone_steps.rb
+++ b/features/step_definitions/barclamp_keystone/keystone_steps.rb
@@ -1,0 +1,54 @@
+Given(/^the chef role "([^"]*)" exists on admin node$/) do |arg1|
+    keystone_server_role = admin_node.exec!("knife role show keystone-server").output
+    expect(keystone_server_role).not_to be_empty
+end
+
+And(/^the "([^"]*)" cookbook exists on the admin node$/) do |arg1|
+    keystone_cookbook = admin_node.exec!("knife cookbook show keystone").output
+    expect(keystone_cookbook).not_to be_empty
+end
+
+And(/^the barclamp proposal is using the keystone identity service$/) do
+    json_response = JSON.parse(admin_node.exec!("crowbar keystone show default").output)
+    @node_fqdn = json_response["deployment"]["keystone"]["elements"]["keystone-server"][0]
+    expect(@node_fqdn).not_to be_empty
+end
+
+When(/^the node with keystone-server role has been detected successfully$/) do
+    user_list = control_node.openstack.user.list
+    expect(user_list).not_to be_empty
+end
+
+And(/^the "([^"]*)" is installed in the controller node$/) do |test_package|
+    control_node.rpm_q(test_package)
+end
+
+And(/^the "([^"]*)" is installed on the controller node$/) do |client_package|
+    control_node.rpm_q(client_package)
+end
+
+Then(/^I can create a new project "([^"]*)" on the cloud$/) do |project_name|
+    response = control_node.openstack.project.create(project_name)
+    puts "Project #{response.name} created with ID: #{response.id}"
+    expect(response.name).to eq(project_name)
+end
+
+And(/^I can create a new user "([^"]*)" for the "([^"]*)" project$/) do |user_name, project_name|
+    response = control_node.openstack.user.create(user_name, 
+                                                   project: project_name)
+    puts "Created user #{response.name} on Project : #{response.project_id}"
+    expect(response.name).to eq(user_name)
+end
+
+And(/^I can see the list of all available hosts on the cloud$/) do
+    host_list = control_node.openstack.host.list
+    puts "List of hosts available"
+    host_list.each do |host|
+        puts "Name: #{host.name}    Service: #{host.service}    Zone: #{host.zone}"
+    end
+end
+
+And(/^I can delete the project "([^"]*)" and user "([^"]*)"$/) do |project_name, user_name|
+    control_node.openstack.user.delete(user_name)
+    control_node.openstack.project.delete(project_name)
+end

--- a/lib/cct/commands/openstack.rb
+++ b/lib/cct/commands/openstack.rb
@@ -22,6 +22,7 @@ module Cct
         attr_reader :project
         attr_reader :network
         attr_reader :role
+        attr_reader :host
 
         # @param [Cct::Node] as the receiver for the openstack client
         def initialize node
@@ -30,6 +31,7 @@ module Cct
           @project = Openstack::Project.new(node)
           @network = Openstack::Network.new(node)
           @role = Openstack::Role.new(node)
+          @host = Openstack::Host.new(node)
         end
 
         def actions
@@ -222,4 +224,5 @@ require 'cct/commands/openstack/user'
 require 'cct/commands/openstack/project'
 require 'cct/commands/openstack/network'
 require 'cct/commands/openstack/role'
+require 'cct/commands/openstack/host'
 

--- a/lib/cct/commands/openstack/host.rb
+++ b/lib/cct/commands/openstack/host.rb
@@ -1,0 +1,13 @@
+module Cct
+  module Commands
+    module Openstack
+      class Host < Command
+        self.command = "host"
+
+        def list *options
+          super(*(options << {row: Struct.new(:name, :service, :zone)}))
+        end
+      end
+    end
+  end
+end

--- a/tasks/features.rake
+++ b/tasks/features.rake
@@ -5,5 +5,11 @@ namespace :features do
     invoke_task "feature:controller"
     invoke_task "feature:users"
     invoke_task "feature:images"
+    invoke_task "feature:barclamps"
+  end
+
+  desc "Test all barclamps"
+  task :barclamps do
+    invoke_task "feature:barclamp:keystone"
   end
 end

--- a/tasks/features/barclamp_keystone.rake
+++ b/tasks/features/barclamp_keystone.rake
@@ -1,0 +1,11 @@
+namespace :feature do
+  feature_name "Tests Openstack Keystone barclamp"
+
+  namespace :barclamp do
+    desc "Barclamp Keystone feature"
+    feature_task :keystone, tags: :@keystone
+
+    desc "Verification of 'Tests Openstack Keystone barclamp' feature"
+    feature_task :all
+  end
+end


### PR DESCRIPTION
Added basic feature tests for keystone with 
- Access to keystone resource lists(eg: services, projects, users, hosts etc) through openstackclient
- create/delete users and project using openstackclient command line interface
- Added new openstack.rb function to the cct library to include command for "openstack host list"
