### PR TITLE
Add section `nodes` into default.yml configuration file

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -25,6 +25,12 @@ control_node:
     password:
     port: 22
 
+nodes:
+  - name:
+    ssh:
+      user: root
+      password: linux
+
 timeout:
   ssh: 5
   http: 5


### PR DESCRIPTION
This solves the failing database tests with exception `Default configuration for nodes not found`, no need to revert the code as in https://github.com/SUSE-Cloud/cct/pull/29 .
