### PR TITLE
RemoteCommandFailed raised only for failure

### DIFF
--- a/lib/cct/remote_command.rb
+++ b/lib/cct/remote_command.rb
@@ -38,7 +38,7 @@ module Cct
       end
       session.loop unless gateway
       result[:success?] = result.exit_code.zero?
-      if !result.success? || result.error.length.nonzero?
+      if !result.success? || (result.error.length.nonzero? && !result.exit_code.zero?)
         log.error(result.output)
         raise RemoteCommandFailed.new(full_command, result)
       end


### PR DESCRIPTION
RemoteCommandFailed was raised even if success = true and error is not empty. 
But some commands have messages like "Done/100% complete" These messages are put into the "error" field and lead to raising RemoteCommandFailed exception. Correction ensures that the exit code is non zero before raising the exception.
