### PR TITLE
Improve search nodes, add custom matchers

### DIFF
--- a/features/support/custom_matchers.rb
+++ b/features/support/custom_matchers.rb
@@ -1,0 +1,24 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :have_succeeded_at_least_once do
+  match do |actual|
+    succeeded = actual.select {|result| result.success? }
+    succeeded.size.nonzero?
+  end
+
+  failure_message do |actual|
+    "expected that #{actual} would contain at least one successful command result"
+  end
+end
+
+RSpec::Matchers.define :match_with_output_at_least_once do |expected|
+  match do |actual|
+    outputs = actual.map(&:output).compact
+    matches = outputs.map {|o| o.match(expected) }.compact
+    matches.size.nonzero?
+  end
+
+  failure_message do |actual|
+    "expected that at least one output value in #{actual} would match '#{expected}'"
+  end
+end

--- a/features/support/custom_matchers.rb
+++ b/features/support/custom_matchers.rb
@@ -1,6 +1,6 @@
 require 'rspec/expectations'
 
-RSpec::Matchers.define :have_succeeded_at_least_once do
+RSpec::Matchers.define :succeed_at_least_once do
   match do |actual|
     succeeded = actual.select {|result| result.success? }
     succeeded.size.nonzero?

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,6 +3,7 @@ require "cct/cloud/world"
 
 require_relative "step_helpers"
 require_relative "feature_helpers"
+require_relative "custom_matchers"
 
 # Guess verbosity from the cli params
 verbose = ARGV.grep(/(--verbose|-v)/).empty? ? false : true

--- a/features/support/feature_helpers.rb
+++ b/features/support/feature_helpers.rb
@@ -1,6 +1,10 @@
 module FeatureHelpers
   attr_reader :scenario_tag, :feature_tag
 
+  def proposal name
+    JSON.parse(admin_node.exec!("crowbar #{name} show default").output)
+  end
+
   def filter_scenario_config_by scenario_tags
     @feature_tag, @scenario_tag = scenario_tags.map(&:name)
   end

--- a/lib/cct/cloud/node.rb
+++ b/lib/cct/cloud/node.rb
@@ -23,9 +23,9 @@ module Cct
       validate_attributes
     end
 
-    def exec! command, *params
+    def exec! command, *params, capture_error: false
       params << environment unless environment.empty?
-      @command.exec!(command, params)
+      @command.exec!(command, params, capture_error: capture_error)
     end
 
     def crowbar reload: false

--- a/lib/cct/cloud/nodes.rb
+++ b/lib/cct/cloud/nodes.rb
@@ -42,7 +42,7 @@ module Cct
     # @param element [String] Element name in the crowbar proposal json tree
     # @note Parameter :barclamp requires element to be specified
     # @return [Array] One or multiple node instances
-    def find name: nil, fqdn: nil, barclamp: nil, element: nil
+    def find name: nil, fqdn: nil, barclamp: nil, element: nil, proposal: "default"
       load!
       return nodes.select {|n| n.name == name } if name
       return nodes.select {|n| n.fqdn == fqdn } if fqdn
@@ -51,7 +51,7 @@ module Cct
         raise "Missing element for barclamp proposal" unless element
 
         proposal = JSON.parse(
-          admin_node.exec!("crowbar #{barclamp} show default").output
+          admin_node.exec!("crowbar #{barclamp} show #{proposal}").output
         )
 
         nodes_detected = []

--- a/lib/cct/cloud/nodes.rb
+++ b/lib/cct/cloud/nodes.rb
@@ -36,14 +36,46 @@ module Cct
       nodes.select {|n| n.name != node.name}
     end
 
-    def find name: nil, fqdn: nil
+    # @param name [String] Hostname of a node
+    # @param fqdn [String] Fully qualified domain name
+    # @param barclamp [String] Name of a barclamp assigned to a node
+    # @param element [String] Element name in the crowbar proposal json tree
+    # @note Parameter :barclamp requires element to be specified
+    # @return [Array] One or multiple node instances
+    def find name: nil, fqdn: nil, barclamp: nil, element: nil
       load!
-      return nodes.find {|n| n.name == name } if name
-      return nodes.find {|n| n.fqdn == fqdn } if fqdn
+      return nodes.select {|n| n.name == name } if name
+      return nodes.select {|n| n.fqdn == fqdn } if fqdn
+
+      if barclamp
+        raise "Missing element for barclamp proposal" unless element
+
+        proposal = JSON.parse(
+          admin_node.exec!("crowbar #{barclamp} show default").output
+        )
+
+        nodes_detected = []
+
+        clustered = proposal["deployment"][barclamp]["elements"][element].first.start_with?("cluster:")
+
+        if clustered
+          nodes_detected.push(
+            proposal["deployment"][barclamp]["elements_expanded"][element]
+          )
+        else
+          nodes_detected.push(
+            proposal["deployment"][barclamp]["elements"][element]
+          )
+        end
+
+        nodes_detected.flatten.compact.map do |node_fqdn|
+          nodes.find {|n| n.fqdn == node_fqdn }
+        end.compact
+      end
     end
 
     def admin_node
-      nodes.find {|node| node.name = AdminNode::NAME }
+      @admin_node ||= nodes.find {|node| node.name == AdminNode::NAME }
     end
 
     def clear
@@ -69,7 +101,6 @@ module Cct
     end
 
     def load_admin name, attrs, node_details
-      admin_node = nodes.find {|n| n.name == AdminNode::NAME}
       if admin_node
         return admin_node.reload! unless admin_node.loaded?
         return admin_node if admin_node.loaded?

--- a/lib/cct/remote_command.rb
+++ b/lib/cct/remote_command.rb
@@ -21,7 +21,7 @@ module Cct
       validate_options
     end
 
-    def exec! command, params=[]
+    def exec! command, params=[], capture_error: false
       log.base.level = ::Logger::WARN
       connect!
       host_ip = gateway ? target.ip : options.ip
@@ -38,9 +38,9 @@ module Cct
       end
       session.loop unless gateway
       result[:success?] = result.exit_code.zero?
-      if !result.success? || result.error.length.nonzero?
+      if !result.success? || (result.error.length.nonzero? && !result.exit_code.zero?)
         log.error(result.output)
-        raise RemoteCommandFailed.new(full_command, result)
+        raise RemoteCommandFailed.new(full_command, result) unless capture_error
       end
       result
     ensure


### PR DESCRIPTION
To be used like:

``` ruby
# returns all nodes assigned to cinder-volume
nodes.find(barclamp: "cinder", element: "cinder-volume")`
```

It works in normal and HA configuration.

The custom matchers make it easier to check for multiple command results:

``` ruby
results = nodes.find(barclamp: "database", element: "database-server").map do |node|
  node.exec! "systemctl is-enabled postgresql", capture_error: true
end
expect(results).to succeed_at_least_once
```
