### PR TITLE
features:barclamps need not run with base tests

### DIFF
--- a/tasks/features.rake
+++ b/tasks/features.rake
@@ -6,7 +6,7 @@ namespace :features do
     invoke_task "test:func:all"
     invoke_task "feature:users"
     invoke_task "feature:images"
-    invoke_task "feature:barclamps"
+    invoke_task "features:barclamps"
   end
 
   desc "Run barclamp tests"


### PR DESCRIPTION
changed feature:barclamps to features:barclamps as expected by rake.
