### PR TITLE
Fix IP address detection

### DIFF
--- a/lib/cct/cloud/nodes.rb
+++ b/lib/cct/cloud/nodes.rb
@@ -119,7 +119,7 @@ module Cct
       if known_config
         nodes << Node.new(
           known_config.merge(
-            ip: node_details["ipaddress"],
+            ip: node_details["crowbar"]["network"]["admin"]["address"],
             crowbar: {
               api: crowbar,
               base: attrs,
@@ -134,7 +134,7 @@ module Cct
       node_config = default_node_config
       nodes << Node.new(
         node_config.merge(
-          ip: node_details["ipaddress"],
+          ip: node_details["crowbar"]["network"]["admin"]["address"],
           name: name,
           crowbar: {
            api: crowbar,


### PR DESCRIPTION
Just using "ipaddress" is wrong as this is the attribute from
ohai and ohai just returns one random ip address from the
host, not a specific one, so the node we're accessing it
from might not have a way to reach that network.

Always use the admin network instead.
