### PR TITLE
Hardcode Image API version to  1

### DIFF
--- a/lib/cct/commands/openstack/image.rb
+++ b/lib/cct/commands/openstack/image.rb
@@ -2,7 +2,7 @@ module Cct
   module Commands
     module Openstack
       class Image < Command
-        self.command = "image"
+        self.command = ["--os-image-api-version", "1", "image"]
 
         def create name, options={}
           super do |params|


### PR DESCRIPTION
All the cct tests use --copy-from, which does not exist in v2 anymore.
