### PR TITLE
Give zypper more time to suceed if locked by other request

### DIFF
--- a/features/step_definitions/admin_node/packages_steps.rb
+++ b/features/step_definitions/admin_node/packages_steps.rb
@@ -9,6 +9,10 @@ Given(/^the following packages are installed:$/) do |table|
 end
 
 Given(/^all dependencies of installed packages are satisfied$/) do
-  admin_node.exec!("zypper", "verify --no-recommends")
+  admin_node.exec!(
+    "zypper", "--non-interactive",
+    "verify --no-recommends",
+    environment: {"ZYPP_LOCK_TIMEOUT" => 120}
+  )
 end
 

--- a/lib/cct/cloud/node.rb
+++ b/lib/cct/cloud/node.rb
@@ -23,8 +23,8 @@ module Cct
       validate_attributes
     end
 
-    def exec! command, *params, capture_error: false
-      params << environment unless environment.empty?
+    def exec! command, *params, capture_error: false, environment: {}
+      params << {environment: environment} unless environment.empty?
       @command.exec!(command, params, capture_error: capture_error)
     end
 


### PR DESCRIPTION
Should solve https://trello.com/c/PMahC09T/106-cct-error-system-management-is-locked-by-the-application-with-pid-1393-zypper

It will wait 2 minutes to succeed and retry the attempt every 5 seconds. 
