### PR TITLE
Added manilaclient functional tests

### DIFF
--- a/features/functional_tests.feature
+++ b/features/functional_tests.feature
@@ -9,3 +9,10 @@ Feature: Openstack Clients Functional Tests
     And the proper cirros test image has been created
     Then all the functional tests for the package "python-novaclient" pass
 
+  @manilaclient
+  Scenario: Manila Client tests
+    Given the test package "python-manilaclient-test" is installed on the controller node
+    And the package "python-manilaclient" is installed on the controller node
+    And the authentication for the "python-manilaclient" is established
+    Then all the functional tests for the package "python-manilaclient" pass
+

--- a/tasks/features/functional_tests.rake
+++ b/tasks/features/functional_tests.rake
@@ -5,6 +5,9 @@ namespace :test do
     desc "Nova client functional tests"
     feature_task :novaclient, tags: :@novaclient
 
+    desc "Manila client functional tests"
+    feature_task :manilaclient, tags: :@manilaclient
+
     desc "Functional tests for all client libraries"
     feature_task :all
   end


### PR DESCRIPTION
CCT tests for manilaclient functional tests. 
This PR is only about being able to run the functional tests from CCT. Most of the basic and important tests are enabled. We can handle the disabled tests and more cleanup on the functional tests itself as a separate activity. 
