### PR TITLE
Remove --format flag for 'add' openstack command

### DIFF
--- a/lib/cct/commands/openstack.rb
+++ b/lib/cct/commands/openstack.rb
@@ -86,7 +86,7 @@ module Cct
         def add name, options={}
           params.clear
           yield params
-          all_params = ["add", name, "--format=shell"].concat(params.extract!(options))
+          all_params = ["add", name].concat(params.extract!(options))
           OpenStruct.new(shell_parse(exec!(all_params).output))
         end
 


### PR DESCRIPTION
Needed due to changes in keystone v3 where command `openstack role add` does not support `--format` anymore.
Should fix gating error in https://github.com/crowbar/crowbar-openstack/pull/116
