### PR TITLE
Enable flag to suppress cleanup errors

### DIFF
--- a/features/step_definitions/functional_tests/functional_tests_steps.rb
+++ b/features/step_definitions/functional_tests/functional_tests_steps.rb
@@ -43,7 +43,8 @@ And(/^the authentication for the "([^"]*)" is established$/) do |package_name|
     insecure: json_keystone["attributes"]["keystone"]["ssl"]["insecure"] ||
       json_manila["attributes"]["manila"]["ssl"]["insecure"],
     admin_auth_url: openrc["OS_AUTH_URL"],
-    share_type: "default"
+    share_type: "default",
+    suppress_errors_in_cleanup: true
   }
   service_name = package_name.match(/python-(.+)/).captures.first
   conf_file = "/etc/#{service_name}/#{service_name}.conf"


### PR DESCRIPTION
Set suppress_errors_in_cleanup to true to avoid Forbidden() errors from client tests . This is also the default setting for Openstack upstream jenkins tests.
