### PR TITLE
Use ssh gateway only if cct is run outside of admin node

### DIFF
--- a/lib/cct.rb
+++ b/lib/cct.rb
@@ -58,5 +58,9 @@ module Cct
       require "cucumber/rake/task"
       Dir.glob(root.to_s + '/tasks/**/*.rake').each { |task| load(task) }
     end
+
+    def running_on_admin_node?
+      File.exist?("/etc/crowbar.install.key")
+    end
   end
 end

--- a/lib/cct/cloud/world.rb
+++ b/lib/cct/cloud/world.rb
@@ -15,7 +15,11 @@ module Cct
         @admin_node = AdminNode.new
         @crowbar = CrowbarApi.new(admin_node.config)
         admin_node.crowbar_proxy = Node::CrowbarProxy.new(api: crowbar)
-        @control_node = ControlNode.new(crowbar: crowbar, gateway: admin_node.attributes)
+        control_node_options = { crowbar: crowbar }
+        if !Cct.running_on_admin_node?
+          control_node_options.merge!(gateway: admin_node.attributes)
+        end
+        @control_node = ControlNode.new(control_node_options)
         @nodes = Nodes.new(crowbar)
         nodes << control_node << admin_node
         @command =


### PR DESCRIPTION
Thanks to @bmwiedemann for pointing at the overhead with accessing the `control_node` through ssh-gateway even when the testsuite is run on admin node. This change makes cct to run faster and easier to debug in CI/mkcloud. Using gateway is still available if cct is run outside of admin node.
Will be backported to cloud6 branches.
