### PR TITLE
Fix openstackclient image list with newer clients

### DIFF
--- a/lib/cct/commands/openstack.rb
+++ b/lib/cct/commands/openstack.rb
@@ -106,7 +106,7 @@ module Cct
           params.clear
           extended = options.last.is_a?(Hash) ? options.pop : {}
           row = extended[:row] || Struct.new(:id, :name)
-          result = exec!("list", "--format=csv", options).output
+          result = exec!("list", "--format=csv", "-c ID", "-c Name", options).output
           csv_parse(result).map do |csv_row|
             row.new(*csv_row)
           end


### PR DESCRIPTION
Newer versions of openstackclient (i.e. 2.2.0) have an extra "status" field
when listing the images. This leads to:

struct size differs (ArgumentError)

So explicit request the columns we want when listing images.
