### PR TITLE
Add upgrade test case for landing page

### DIFF
--- a/features/upgrade_feature.feature
+++ b/features/upgrade_feature.feature
@@ -1,0 +1,19 @@
+Feature: Upgrade cloud via browser UI
+  As a cloud administrator
+  I want to upgrade deployed cloud
+  In order to use the latest SLE, crowbar and openstack version
+
+  Background:
+    Given the admin node responds to a ping
+    And I can establish SSH connection
+    And I can reach the crowbar API
+    And the admin node is in "ready" state
+
+  @landing
+  Scenario: Landing page
+    Given I click the "Upgrade" link to trigger the upgrade process
+    And the upgrade process is successfuly initialized
+    When I trigger the preliminary checks by clicking on "Run checks"
+    Then all checks show successful results
+    And  I get the "Begin Upgrade" button enabled
+

--- a/tasks/features/ui_upgrade.rake
+++ b/tasks/features/ui_upgrade.rake
@@ -1,0 +1,16 @@
+namespace :feature do
+  feature_name "Upgrade cloud via browser UI"
+
+
+  namespace :ui do
+    namespace :upgrade do
+      desc "Landing page"
+      feature_task :landing, tags: :@landing
+
+      feature_task :all
+    end
+
+    desc "Run all upgrade steps"
+    task :upgrade => "upgrade:all"
+  end
+end


### PR DESCRIPTION
Added new task for running the upgrade landing test: 
`rake feature:ui:upgrade:landing`

Depends on code added in https://github.com/SUSE-Cloud/cct/pull/58 (already merged)
