### PR TITLE
Enable headless UI testing

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,4 +1,3 @@
 ---
 BUNDLE_PATH: vendor/bundle
 BUNDLE_DISABLE_SHARED_GEMS: true
-BUNDLE_WITHOUT: ui_tests

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,11 @@ gemspec
 group :ui_tests do
   gem "rack", "~> 1.6" # higher versions require ruby 2.2.2
   gem "capybara"
+  gem "capybara-screenshot"
   # mandatory rpm dependencies for webkit gem
-  # zypper install libqt4-devel libQtWebKit-devel   # 120+ packages as deps
-  gem "capybara-webkit"
+  # zypper install libqt4-devel libQtWebKit-devel xorg-x11-server xorg-x11-server-extra
+  gem "capybara-webkit", "~> 1.11.1"
+  # mandatory rpm dependencies for headless gem
+  # zypper install xorg-x11-server xorg-x11-server-extra
+  gem "headless"
 end


### PR DESCRIPTION
- enable making screenshots for failed UI tests
- don't use `BUNDLE_WITHOUT` config value as the bundler in SP2 does not support `--with ui_tests` option that is needed to use install all needed gems; it only supports `--without`
