### PR TITLE
Raise node unknown node state timeout

### DIFF
--- a/features/step_definitions/controller_node/background_steps.rb
+++ b/features/step_definitions/controller_node/background_steps.rb
@@ -17,7 +17,7 @@ end
 Given(/^the controller node is in "([^"]*)" state$/) do |ready|
   # before checking for "ready" state, make sure the controller is not
   # in an "unknown" state
-  20.times do
+  60.times do
     break unless control_node.status == "unknown"
     sleep 5
   end


### PR DESCRIPTION
The nodes need some more time to get ready in the HA case.
