### PR TITLE
Add tests for the landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Gemfile.lock
 /log
 *.swp
 *.swo
+screenshot*

--- a/features/step_definitions/upgrade/landing_page_steps.rb
+++ b/features/step_definitions/upgrade/landing_page_steps.rb
@@ -1,0 +1,35 @@
+Given(/^I click the "([^"]*)" link to trigger the upgrade process$/) do |link|
+  #FIXME link is currently not implemented, see bsc#1016923
+  visit('/upgrade')
+end
+
+Given(/^the upgrade process is successfuly initialized$/) do
+  find(".navbar-header", text: "Upgrade 6-7")
+end
+
+When(/^I click the "([^"]*)" button to trigger preliminary checks$/) do |button_text|
+  check_button = find_button(button_text)
+  check_button.click
+  expect(check_button.disabled?).to be(true)
+  expect(check_button.find("suse-lazy-spinner").visible?).to be(true)
+  wait_for "Prechecks to finish", max: "60 seconds", sleep: "5 seconds" do
+    break if !check_button.disabled?
+  end
+end
+
+Then(/^all checks show successful results$/) do
+  checklist = find("crowbar-checklist")
+  failed_prechecks = checklist.find("ul").all("li").find_all do |item|
+    !item[:class].match("text-success")
+  end
+  if !failed_prechecks.empty?
+    raise "Prechecks failed:\n#{failed_prechecks.map {|p| p.text}.join("\n")}\n"
+  end
+end
+
+Then(/^I get the "([^"]*)" button enabled$/) do |button_text|
+  upgrade_button = find_button(button_text)
+  expect(upgrade_button.disabled?).to be false
+end
+
+

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -86,5 +86,7 @@ if configure_ui_tests
     config.allow_url(crowbar["ip"])
   end
 
+  Capybara.default_max_wait_time = 5
+
   World(Capybara)
 end

--- a/features/upgrade.feature
+++ b/features/upgrade.feature
@@ -13,7 +13,7 @@ Feature: Upgrade cloud via browser UI
   Scenario: Landing page
     Given I click the "Upgrade" link to trigger the upgrade process
     And the upgrade process is successfuly initialized
-    When I trigger the preliminary checks by clicking on "Run checks"
+    When I click the "Check" button to trigger preliminary checks
     Then all checks show successful results
     And  I get the "Begin Upgrade" button enabled
 


### PR DESCRIPTION
* going from dashboard to upgrade UI
* triggering prechecks
* checking for enabling Begin upgrade button

Before running these tests you need to set system var `cct_ui_tests=true`, otherwise the UI testing will not get enabled.