### PR TITLE
Do not expect to get spinners on buttons during upgrade via UI

### DIFF
--- a/features/step_definitions/upgrade/admin_backup_steps.rb
+++ b/features/step_definitions/upgrade/admin_backup_steps.rb
@@ -6,7 +6,6 @@ Given(/^I click the "([^"]*)" button on the landing page$/) do |button_text|
     verify_upgrade_landing_page
     upgrade_button = find_button(button_text)
     upgrade_button.click
-    expect(upgrade_button.find("suse-lazy-spinner").visible?).to be(true)
   end
 
   wait_for "Starting upgrade workflow", max: "80 seconds", sleep: "10 seconds" do

--- a/features/step_definitions/upgrade/landing_page_steps.rb
+++ b/features/step_definitions/upgrade/landing_page_steps.rb
@@ -11,7 +11,6 @@ When(/^I click the "([^"]*)" button to trigger preliminary checks$/) do |button_
   check_button = find_button(button_text)
   check_button.click
   expect(check_button.disabled?).to be(true)
-  expect(check_button.find("suse-lazy-spinner").visible?).to be(true)
   wait_for "Prechecks to finish", max: "60 seconds", sleep: "5 seconds" do
     break if !check_button.disabled?
   end


### PR DESCRIPTION
Spinners seem to have disappeared from buttons on the latest upgrade UI