### PR TITLE
Add tests for admin upgrade but do not trigger upgrade

### DIFF
--- a/features/step_definitions/upgrade/admin_upgrade_steps.rb
+++ b/features/step_definitions/upgrade/admin_upgrade_steps.rb
@@ -1,0 +1,11 @@
+Given(/^I am on the page for upgrade admin server$/) do
+  visit('/upgrade')
+  sleep 5
+  if page.current_url.match(/administration-repositories-checks$/)
+    verify_upgrade_admin_repos_page
+  end
+  wait_for "Show upgrade admin page", max: "10 seconds", sleep: "1 seconds" do
+    puts "Current url: #{page.current_url}"
+    break if page.current_url.match(/upgrade-administration-server$/)
+  end
+end

--- a/features/support/step_helpers.rb
+++ b/features/support/step_helpers.rb
@@ -21,4 +21,13 @@ module StepHelpers
     step 'the "Next" button gets enabled'
     step 'I click the "Next" button to move to next upgrade action'
   end
+
+  def verify_upgrade_admin_repos_page
+    step 'I am on the page for admin repo checks for upgrade workflow'
+    step 'the "Check" button is available and enabled'
+    step 'the "Next" button is available and disabled'
+    step 'I click the "Check" button to verify new cloud repos on admin node'
+    step 'I get successful results for all repos'
+    step 'I click the "Next" button to move to next upgrade action'
+  end
 end

--- a/features/upgrade.feature
+++ b/features/upgrade.feature
@@ -34,4 +34,11 @@ Feature: Upgrade cloud via browser UI
     And the "Next" button is available and disabled
     When I click the "Check" button to verify new cloud repos on admin node
     Then I get successful results for all repos
+    And I click the "Next" button to move to next upgrade action
+
+  @admin_upgrade
+  Scenario: Admin server upgrade
+    Given I am on the page for upgrade admin server
+    And button for "Upgrade Administration Server" is available and enabled
+    And the "Next" button is disabled
 

--- a/tasks/features/ui_upgrade.rake
+++ b/tasks/features/ui_upgrade.rake
@@ -13,6 +13,9 @@ namespace :feature do
       desc "Admin repo checks"
       feature_task :"admin:repos", tags: :@admin_repos
 
+      desc "Admin server upgrade"
+      feature_task :"admin:upgrade", tags: :@admin_upgrade
+
       feature_task :all
     end
 


### PR DESCRIPTION
Add verification of the upgrade page but don't trigger the upgrade as cct is running on admin node, that must be done manually via UI or crowbarctl as is done in the jenkins job. 